### PR TITLE
add support for symfony 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": [ "propel", "behavior", "event dispatcher", "event" ],
     "license": "MIT",
     "require": {
-        "symfony/event-dispatcher": "~2.1",
+        "symfony/event-dispatcher": "~2.1|~3.0",
         "propel/propel1": "~1.6"
     },
     "authors": [


### PR DESCRIPTION
Update version in composer.json to allow symfony/eventdispatcher for 3.x
